### PR TITLE
Moving to version 2022.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "molsystem" %}
-{% set version = "2022.1.17" %}
-{% set sha256 = "29e8890319b51376e38abba6d4d4354b49f67f1a75bacbea965e75082bf3a64b" %}
+{% set version = "2022.2.1" %}
+{% set sha256 = "cd513ba32399b08612c70d9eda2790abb55bd92cce684f8e387ba778b1af2cf4" %}
 
 package:
   name: {{ name|lower }}
@@ -28,6 +28,8 @@ requirements:
     - pycifrw
     - python >=3.8
     - rdkit
+    - seekpath
+    - spglib
 
 test:
   imports:


### PR DESCRIPTION
This adds space group symmetry, which requires two new dependencies: `seekpath` and `spglib`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
